### PR TITLE
Require `setuptools` and `pip` at run-time

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,7 +8,7 @@ source:
   md5: f42ec0ed1ce5e09e5ef5d3ce4f9826e6
 
 build:
-  number: 0
+  number: 1
   skip: True  # [py2k or not linux]
 
 requirements:
@@ -21,6 +21,8 @@ requirements:
 
   run:
     - python
+    - setuptools
+    - pip
     - pyelftools
     - typing      # [py<35]
 


### PR DESCRIPTION
Fixes https://github.com/conda-forge/auditwheel-feedstock/issues/5