### PR TITLE
Refresh the feedstock

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+* text=auto
+
+meta.yaml text eol=lf
+build.sh text eol=lf
+bld.bat text eol=crlf

--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,5 @@
 BSD 3-clause license
-Copyright (c) conda-forge
+Copyright (c) 2015-2017, conda-forge
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/README.md
+++ b/README.md
@@ -11,6 +11,18 @@ Summary: Linux wheel verification tool to ensure compatibility
 
 
 
+Current build status
+====================
+
+Linux: [![Circle CI](https://circleci.com/gh/conda-forge/auditwheel-feedstock.svg?style=shield)](https://circleci.com/gh/conda-forge/auditwheel-feedstock)
+OSX: ![](https://cdn.rawgit.com/conda-forge/conda-smithy/90845bba35bec53edac7a16638aa4d77217a3713/conda_smithy/static/disabled.svg)
+Windows: ![](https://cdn.rawgit.com/conda-forge/conda-smithy/90845bba35bec53edac7a16638aa4d77217a3713/conda_smithy/static/disabled.svg)
+
+Current release info
+====================
+Version: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/auditwheel/badges/version.svg)](https://anaconda.org/conda-forge/auditwheel)
+Downloads: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/auditwheel/badges/downloads.svg)](https://anaconda.org/conda-forge/auditwheel)
+
 Installing auditwheel
 =====================
 
@@ -31,7 +43,6 @@ It is possible to list all of the versions of `auditwheel` available on your pla
 ```
 conda search auditwheel --channel conda-forge
 ```
-
 
 
 About conda-forge
@@ -67,18 +78,6 @@ Terminology
 
 **conda-forge** - the place where the feedstock and smithy live and work to
                   produce the finished article (built conda distributions)
-
-Current build status
-====================
-
-Linux: [![Circle CI](https://circleci.com/gh/conda-forge/auditwheel-feedstock.svg?style=shield)](https://circleci.com/gh/conda-forge/auditwheel-feedstock)
-OSX: ![](https://cdn.rawgit.com/conda-forge/conda-smithy/90845bba35bec53edac7a16638aa4d77217a3713/conda_smithy/static/disabled.svg)
-Windows: ![](https://cdn.rawgit.com/conda-forge/conda-smithy/90845bba35bec53edac7a16638aa4d77217a3713/conda_smithy/static/disabled.svg)
-
-Current release info
-====================
-Version: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/auditwheel/badges/version.svg)](https://anaconda.org/conda-forge/auditwheel)
-Downloads: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/auditwheel/badges/downloads.svg)](https://anaconda.org/conda-forge/auditwheel)
 
 
 Updating auditwheel-feedstock

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ About auditwheel
 
 Home: https://github.com/pypa/auditwheel
 
-Package license: MIT License
+Package license: MIT
 
 Feedstock license: BSD 3-Clause
 

--- a/ci_support/fast_finish_ci_pr_build.sh
+++ b/ci_support/fast_finish_ci_pr_build.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+curl https://raw.githubusercontent.com/conda-forge/conda-forge-build-setup-feedstock/master/recipe/ff_ci_pr_build.py | \
+     python - -v --ci "circle" "${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}" "${CIRCLE_BUILD_NUM}" "${CIRCLE_PR_NUMBER}"

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -43,9 +43,15 @@ conda clean --lock
 conda install --yes --quiet conda-forge-build-setup
 source run_conda_forge_build_setup
 
-# Embarking on 1 case(s).
+# Embarking on 2 case(s).
     set -x
     export CONDA_PY=35
+    set +x
+    conda build /recipe_root --quiet || exit 1
+    upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
+
+    set -x
+    export CONDA_PY=36
     set +x
     conda build /recipe_root --quiet || exit 1
     upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -14,7 +14,7 @@ config=$(cat <<CONDARC
 
 channels:
  - conda-forge
- - defaults # As we need conda-build
+ - defaults
 
 conda-build:
  root-dir: /feedstock_root/build_artefacts
@@ -24,12 +24,14 @@ show_channel_urls: true
 CONDARC
 )
 
+rm -f "$FEEDSTOCK_ROOT/build_artefacts/conda-forge-build-done"
+
 cat << EOF | docker run -i \
-                        -v ${RECIPE_ROOT}:/recipe_root \
-                        -v ${FEEDSTOCK_ROOT}:/feedstock_root \
+                        -v "${RECIPE_ROOT}":/recipe_root \
+                        -v "${FEEDSTOCK_ROOT}":/feedstock_root \
                         -a stdin -a stdout -a stderr \
                         condaforge/linux-anvil \
-                        bash || exit $?
+                        bash || exit 1
 
 export BINSTAR_TOKEN=${BINSTAR_TOKEN}
 export PYTHONUNBUFFERED=1
@@ -41,16 +43,17 @@ conda clean --lock
 conda install --yes --quiet conda-forge-build-setup
 source run_conda_forge_build_setup
 
-# Embarking on 2 case(s).
-    set -x
-    export CONDA_PY=34
-    set +x
-    conda build /recipe_root --quiet || exit 1
-    upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
-
+# Embarking on 1 case(s).
     set -x
     export CONDA_PY=35
     set +x
     conda build /recipe_root --quiet || exit 1
     upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
+touch /feedstock_root/build_artefacts/conda-forge-build-done
 EOF
+
+# double-check that the build got to the end
+# see https://github.com/conda-forge/conda-smithy/pull/337
+# for a possible fix
+set -x
+test -f "$FEEDSTOCK_ROOT/build_artefacts/conda-forge-build-done" || exit 1

--- a/circle.yml
+++ b/circle.yml
@@ -1,5 +1,6 @@
 checkout:
   post:
+    - ./ci_support/fast_finish_ci_pr_build.sh
     - ./ci_support/checkout_merge_commit.sh
 
 machine:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,11 +15,9 @@ build:
 
 requirements:
   build:
-    - pbr
     - python
     - setuptools
-    - pyelftools
-    - typing      # [py<35]
+    - pbr
 
   run:
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 8cf3e4302361447e76a6b4ff452bce01f9905e349365850774c3e16a8448b0ce
 
 build:
-  number: 0
+  number: 1
   skip: True  # [py2k or not linux]
   entry_points:
     - auditwheel = auditwheel.main:main

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@ package:
 source:
   fn: auditwheel-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/a/auditwheel/auditwheel-{{ version }}.tar.gz
-  md5: 2b989cb308ced9b237bae343653cc8ba
+  sha256: 8cf3e4302361447e76a6b4ff452bce01f9905e349365850774c3e16a8448b0ce
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,7 +32,7 @@ test:
 
 about:
   home: https://github.com/pypa/auditwheel
-  license: MIT License
+  license: MIT
   summary: Linux wheel verification tool to ensure compatibility
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,6 +12,8 @@ source:
 build:
   number: 0
   skip: True  # [py2k or not linux]
+  entry_points:
+    - auditwheel = auditwheel.main:main
 
 requirements:
   build:


### PR DESCRIPTION
Closes https://github.com/conda-forge/auditwheel-feedstock/pull/13

* Re-renders the feedstock with `conda-smithy` 2.2.2.
* Switches to sha256.
* Drops unneeded build requirements.
* Drops "License" from `license` metadata.
* Adds entry points.
* Bumps the build number to 1.